### PR TITLE
Remove Duplicate File Extension

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,7 +107,7 @@ if (PNGImages) {
       verbose: !argv.mute,
       silent: false,
     }))
-    .pipe(rename({ prefix: argv.prefix, suffix: `${argv.suffix}`, extname: '.webp' }))
+    .pipe(rename({ prefix: argv.prefix, suffix: argv.suffix, extname: '.webp' }))
     .pipe(gulp.dest(target));
 }
 
@@ -119,6 +119,6 @@ if (JPGImages) {
       verbose: !argv.mute,
       silent: false,
     }))
-    .pipe(rename({ prefix: argv.prefix, suffix: `${argv.suffix}`, extname: '.webp' }))
+    .pipe(rename({ prefix: argv.prefix, suffix: argv.suffix, extname: '.webp' }))
     .pipe(gulp.dest(target));
 }

--- a/index.js
+++ b/index.js
@@ -107,7 +107,7 @@ if (PNGImages) {
       verbose: !argv.mute,
       silent: false,
     }))
-    .pipe(rename({ prefix: argv.prefix, suffix: `${argv.suffix}.png`, extname: '.webp' }))
+    .pipe(rename({ prefix: argv.prefix, suffix: `${argv.suffix}`, extname: '.webp' }))
     .pipe(gulp.dest(target));
 }
 
@@ -119,6 +119,6 @@ if (JPGImages) {
       verbose: !argv.mute,
       silent: false,
     }))
-    .pipe(rename({ prefix: argv.prefix, suffix: `${argv.suffix}.jpg`, extname: '.webp' }))
+    .pipe(rename({ prefix: argv.prefix, suffix: `${argv.suffix}`, extname: '.webp' }))
     .pipe(gulp.dest(target));
 }

--- a/index.test.js
+++ b/index.test.js
@@ -180,7 +180,7 @@ describe('Convert Images', () => {
       const stdout = await runCLI(`${SAMPLE_DIRECTORY}/KittenPNG.png --prefix="img-" --suffix="-compressed"`);
       outputImg = getOutputImages();
       expect(outputImg.children.length).toBe(2);
-      expect(outputImg.children[1].name).toMatch('img-KittenPNG-compressed.png.webp');
+      expect(outputImg.children[1].name).toMatch('img-KittenPNG-compressed.webp');
       expect(stdout.match(/Minified 1 image/g)).toHaveLength(1);
     });
   });


### PR DESCRIPTION
Currently the script will rename the file from its original name to its original name with ".png" or ".jpg" appended on. For example, "test.png" will be renamed "test.png.webp". This is rather redundant and tedious when using assets in JavaScript or CSS especially. I've updated the script to only pass the file name rather than the file name with the old extension, so "test.png" would become "test.webp". 